### PR TITLE
Removing illegal character that forces a W3C error

### DIFF
--- a/css/easy-author-image.css
+++ b/css/easy-author-image.css
@@ -10,7 +10,7 @@
 	-moz-box-shadow: 0 0 8px rgba(0, 0, 0, .8);
 }
 
-.circular-medium§ {
+.circular-medium {
 	width: 150px;
 	height: 150px;
 	margin: 0 auto; /* this will center the image */


### PR DESCRIPTION
Using the [W3C Validator](https://validator.w3.org) it throws a fatal error due to a typo in this stylesheet. The character in question has no effect on styling.

Our error, for reference: 
* Sorry, I am unable to validate this document because on line 62 it contained one or more bytes that I cannot interpret as utf-8 (in other words, the bytes found are not valid values in the specified Character Encoding). Please check both the content of the file and the character encoding indication.
The error was: utf8 "\xA7" does not map to Unicode